### PR TITLE
The -nostartfiles and -nodefaultlibs aren't ld flags, but gcc flags

### DIFF
--- a/rffe-board/scripts/Make.defs
+++ b/rffe-board/scripts/Make.defs
@@ -98,10 +98,10 @@ LIBEXT = .a
 EXEEXT =
 
 ifneq ($(CROSSDEV),arm-nuttx-elf-)
-  LDFLAGS += -nostartfiles -nodefaultlibs
+  CFLAGS += -nostartfiles -nodefaultlibs
 endif
 ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
-  LDFLAGS += -g
+  CFLAGS += -g
 endif
 
 


### PR DESCRIPTION
New GNU ld versions will emit an error if you pass these flags, add them to CFLAGS instead.