### PR TITLE
 Use RFFEFWUpdate constructor directly to avoid unnecessary connections 

### DIFF
--- a/utils/fw_update.py
+++ b/utils/fw_update.py
@@ -21,7 +21,7 @@ except:
 
 print("Connecting to " + ip_addr + " ...")
 try:
-    rffe = RFFEControllerBoard(ip_addr)
+    rffe = RFFEFWUpdate(ip_addr)
 except:
     print("Couldn't connect to device!")
     exit(1)


### PR DESCRIPTION
- The script incorrectly calls RFFEControllerBoard instead of RFFEFWUpdate when updating the firmware.